### PR TITLE
feat: allow to inject backdrop element via slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ $ yarn add vue-thin-modal
 
   Same as `content-transition` except for the modal backdrop.
 
+#### Slots
+
+* `(default)` - A modal content. Must be only element.
+
+* `backdrop` - A modal backdrop element.
+
 ### `this.$modal` mediator
 
 #### Properties

--- a/play/BackdropSlot.vue
+++ b/play/BackdropSlot.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <button @click="$modal.push('example')">Open modal</button>
+    <modal name="example">
+      <div slot="backdrop" class="example-backdrop">Inserted backdrop</div>
+      <div>
+        <h1 class="title">Backdrop Slot</h1>
+        <button @click="$modal.pop()">Close modal</button>
+      </div>
+    </modal>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      disableBackdrop: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+.title {
+  margin: 0;
+  font-weight: normal;
+}
+
+.example-backdrop {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(48, 112, 196, 0.7);
+  font-size: 20px;
+  z-index: 1000;
+}
+</style>

--- a/play/index.js
+++ b/play/index.js
@@ -6,9 +6,11 @@ import '../dist/vue-thin-modal.css'
 
 import Simple from './Simple.vue'
 import DisableBackdrop from './disableBackdrop.vue'
+import BackdropSlot from './BackdropSlot.vue'
 
 Vue.use(VueModal)
 
 play('Vue Modal')
   .add('Simple', Simple)
   .add('DisableBackdrop', DisableBackdrop)
+  .add('BackdropSlot', BackdropSlot)

--- a/src/components/Backdrop.js
+++ b/src/components/Backdrop.js
@@ -11,7 +11,7 @@ export default {
     backdropTransition: Object
   },
 
-  render (h: Function, { props, data }: any) {
+  render (h: Function, { props, data, slots }: any) {
     const listeners = data.on || {}
     const { show, backdropTransition } = props
 
@@ -21,7 +21,7 @@ export default {
     )
 
     return h('transition', transitionData, [
-      show && h('div', { staticClass: 'modal-backdrop' })
+      show && (slots().default || h('div', { staticClass: 'modal-backdrop' }))
     ])
   }
 }

--- a/src/components/ModalContent.js
+++ b/src/components/ModalContent.js
@@ -12,10 +12,10 @@ export default {
     contentTransition: Object
   },
 
-  render (h: Function, { props, data, children }: any) {
+  render (h: Function, { props, data, slots }: any) {
     const listeners = data.on || {}
     const { show, disableBackdrop, contentTransition } = props
-    const child = ensureOnlyChild(children)
+    const child = ensureOnlyChild(slots().default || [])
 
     if (child) {
       addStaticClass(child.data, 'modal-content')

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -7,11 +7,18 @@ import { wait, noop } from '../utils'
 
 const openClassBody = 'modal-open'
 
+interface ModalSlots {
+  default?: any[];
+  backdrop?: any[];
+}
+
 export default {
   name: 'modal-portal',
 
   methods: {
-    update (name: string, current: string, props: any, children: any[]) {
+    update (name: string, current: string, props: any, slots: ModalSlots) {
+      const children = slots.default || []
+
       // Inject key into children vnode
       children.forEach(child => {
         if (child.key) return
@@ -25,7 +32,8 @@ export default {
       this._current = current
       this._modals[name] = {
         props,
-        children
+        children,
+        backdrop: slots.backdrop
       }
 
       this.scheduleUpdate()
@@ -71,7 +79,8 @@ export default {
             close: () => this.$emit('close')
           }
         },
-        modal.children
+        modal.children,
+        modal.backdrop
       )
     } else {
       const numTransition = 2
@@ -87,10 +96,10 @@ export default {
   }
 }
 
-function createModalVNode (h: Function, data: any, children: any[]) {
+function createModalVNode (h: Function, data: any, children: any[], backdrop: ?any) {
   return (
     h('div', { staticClass: 'modal-wrapper' }, [
-      h(Backdrop, data),
+      h(Backdrop, data, backdrop),
       h(ModalContent, data, children)
     ])
   )

--- a/src/generators/Modal.js
+++ b/src/generators/Modal.js
@@ -58,7 +58,7 @@ export function generateModal (Vue: any, mediator: Mediator) {
         backdropTransition: this.backdropTransition,
         contentTransition: this.contentTransition,
         disableBackdrop: this.disableBackdrop
-      }, this.$slots.default)
+      }, this.$slots)
     }
   }
 }


### PR DESCRIPTION
Currently, there are no ways to change backdrop styles with different modals. This patch allows users to change backdrops element with `<slot>`.

Example:

```vue
<modal>
  <div slot="backdrop" class="backdrop"></div>
  <div class="content">
    This is content
  </div>
</modal>
```

The above code will be the below modal:

```vue
<div class="modal-wrapper">
  <div class="backdrop"></div> <!-- This is inserted backdrop -->
  <div role="dialog" aria-hidden="false" class="modal-content-wrapper">
    <div class="modal-content">
      This is content
    </div>
  </div>
</div>
```