### PR TITLE
feat: add pre-mount prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,13 @@ $ yarn add vue-thin-modal
 
   Required as the modal name. The `name` must be unique against every modal you would use.
 
+* `pre-mount` - Boolean
+
+  If `true`, the modal contents will be pre mounted into the DOM tree. It is useful if you want to pre load the large images on your modal contents before opened.
+
 * `disable-backdrop` - Boolean
 
-  If `true`, The modal will not be closed by clicking backdrop.
+  If `true`, the modal will not be closed by clicking backdrop.
 
 * `content-transition` - Object
 

--- a/play/PreMount.vue
+++ b/play/PreMount.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <button type="button" @click="$modal.push('image')">Open Modal</button>
+    <p>{{ !loaded ? 'Modal image is loading...' : 'Modal image is loaded' }}</p>
+    <modal name="image" pre-mount>
+      <div class="modal">
+        <img
+          class="modal-image"
+          src="http://via.placeholder.com/3000x3000"
+          alt="" @load="loaded = true"
+        >
+      </div>
+    </modal>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      loaded: false
+    }
+  }
+}
+</script>
+
+<style scoped>
+.modal,
+.modal-image {
+  max-width: 100%;
+}
+</style>

--- a/play/index.js
+++ b/play/index.js
@@ -8,7 +8,8 @@ import Simple from './Simple.vue'
 import DisableBackdrop from './disableBackdrop.vue'
 import BackdropSlot from './BackdropSlot.vue'
 import Scroll from './Scroll.vue'
-import ScrollSemanticUi from './ScrollSemanticUi'
+import ScrollSemanticUi from './ScrollSemanticUi.vue'
+import PreMount from './PreMount.vue'
 
 Vue.use(VueModal)
 
@@ -18,3 +19,4 @@ play('Vue Modal')
   .add('BackdropSlot', BackdropSlot)
   .add('Scroll', Scroll)
   .add('ScrollSemanticUi', ScrollSemanticUi)
+  .add('PreMount', PreMount)

--- a/src/generators/Modal.js
+++ b/src/generators/Modal.js
@@ -16,6 +16,7 @@ export function generateModal (Vue: any, mediator: Mediator) {
         required: true
       },
       disableBackdrop: Boolean,
+      preMount: Boolean,
       backdropTransition: {
         type: Object,
         default () {
@@ -48,7 +49,7 @@ export function generateModal (Vue: any, mediator: Mediator) {
       portal.unregister()
     },
 
-    render () {
+    render (h: Function) {
       if (this.current && !portal.$el.parentNode) {
         appendToBody(portal.$el)
       }
@@ -59,6 +60,14 @@ export function generateModal (Vue: any, mediator: Mediator) {
         contentTransition: this.contentTransition,
         disableBackdrop: this.disableBackdrop
       }, this.$slots)
+
+      return this.preMount && this.current !== this.name
+        ? h('div', {
+          style: {
+            display: 'none'
+          }
+        }, this.$slots.default)
+        : h()
     }
   }
 }


### PR DESCRIPTION
This PR adds `pre-mount` prop to `<Modal>` component. If we specify the prop `true`, the modal contents will be mounted on the DOM tree as hidden element before we open the modal. This feature is useful when the users want to pre load the images on the modal contents before they open the modal.