### PR TITLE
refactor: simplify to gather transition event

### DIFF
--- a/src/components/Backdrop.js
+++ b/src/components/Backdrop.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { onAfterLeave } from '../utils'
-
 export default {
   functional: true,
   name: 'backdrop',
@@ -15,10 +13,10 @@ export default {
     const listeners = data.on || {}
     const { show, backdropTransition } = props
 
-    const transitionData = onAfterLeave(
-      { props: backdropTransition },
-      listeners.leave
-    )
+    const transitionData = {
+      props: backdropTransition,
+      on: listeners
+    }
 
     return h('transition', transitionData, [
       show && (slots().default || h('div', { staticClass: 'modal-backdrop' }))

--- a/src/components/ModalContent.js
+++ b/src/components/ModalContent.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { addStaticClass, onAfterLeave, assert } from '../utils'
+import { addStaticClass, assert } from '../utils'
 
 export default {
   functional: true,
@@ -21,10 +21,10 @@ export default {
       addStaticClass(child.data, 'modal-content')
     }
 
-    const transitionData = onAfterLeave(
-      { props: contentTransition },
-      listeners.leave
-    )
+    const transitionData = {
+      props: contentTransition,
+      on: listeners
+    }
 
     return (
       h('div', {
@@ -38,8 +38,8 @@ export default {
             if (disableBackdrop) return
             if (event.target !== event.currentTarget) return
 
-            if (listeners.close) {
-              listeners.close()
+            if (listeners['click-backdrop']) {
+              listeners['click-backdrop']()
             }
           }
         }

--- a/src/generators/Modal.js
+++ b/src/generators/Modal.js
@@ -41,7 +41,7 @@ export function generateModal (Vue: any, mediator: Mediator) {
       if (!portal) {
         portal = new Vue(ModalPortal)
           .$mount()
-          .$on('close', () => mediator.pop())
+          .$on('click-backdrop', () => mediator.pop())
       }
     },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,5 @@
 // @flow
 
-export function noop () {}
-
 export function addStaticClass (
   data: { staticClass: ?string },
   staticClass: string
@@ -13,35 +11,22 @@ export function addStaticClass (
   }
 }
 
-export function wait (times: number, cb: () => void): () => void {
+function pruneCallbackByCount (predicate: (count: number) => boolean, cb: () => void) {
   let count = 0
   return () => {
     count += 1
-    if (count >= times) {
+    if (predicate(count)) {
       cb()
     }
   }
 }
 
-export function onAfterLeave (vnodeData: Object, cb: ?() => void): Object {
-  if (!cb) return vnodeData
+export function only (times: number, cb: () => void): () => void {
+  return pruneCallbackByCount(count => count <= times, cb)
+}
 
-  const hooks = vnodeData.on || {}
-  const prev: Function = hooks.afterLeave
-
-  if (prev) {
-    hooks.afterLeave = el => {
-      prev(el)
-      // $FlowFixMe: ignore null type
-      cb()
-    }
-  } else {
-    hooks.afterLeave = cb
-  }
-
-  vnodeData.on = hooks
-
-  return vnodeData
+export function wait (times: number, cb: () => void): () => void {
+  return pruneCallbackByCount(count => count >= times, cb)
 }
 
 export function assert (value: any, message: string): void {


### PR DESCRIPTION
* simplify the render function of ModalPortal
  * abstract transition events to `before-open` / `opened` / `before-close` / `closed` events so that we can easily write some processing following such event more clean way.