### PR TITLE
feat: allow events for modal component

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ $ yarn add vue-thin-modal
 
   Same as `content-transition` except for the modal backdrop.
 
+#### Events
+
+* `before-open`
+
+  Emitted before opening a modal.
+
+* `opened`
+
+  Emitted after opening a modal.
+
+* `before-close`
+
+  Emitted before closing a modal.
+
+* `closed`
+
+  Emitted after closing a modal.
+
 #### Slots
 
 * `(default)` - A modal content. Must be only element.

--- a/play/Events.vue
+++ b/play/Events.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <button type="button" @click="onClick">Show Modal</button>
+    <p>Emitted Events</p>
+    <ul>
+      <li v-for="(text, i) in log" :key="i">{{ text }}</li>
+    </ul>
+    <modal
+      name="foo"
+      @before-open="log.push('before-open')"
+      @opened="log.push('opened')"
+      @before-close="log.push('before-close')"
+      @closed="log.push('closed')"
+    >
+      <div class="basic-modal">
+        <h1 class="title">Foo</h1>
+        <button class="button" type="button" @click="close">Close</button>
+      </div>
+    </modal>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      log: []
+    }
+  },
+
+  methods: {
+    open (name) {
+      this.$modal.push(name)
+    },
+
+    close () {
+      this.$modal.pop()
+    },
+
+    onClick () {
+      this.open('foo')
+    }
+  }
+}
+</script>
+
+<style scoped>
+.title {
+  margin: 0;
+  font-weight: normal;
+}
+</style>

--- a/play/index.js
+++ b/play/index.js
@@ -10,6 +10,7 @@ import BackdropSlot from './BackdropSlot.vue'
 import Scroll from './Scroll.vue'
 import ScrollSemanticUi from './ScrollSemanticUi.vue'
 import PreMount from './PreMount.vue'
+import Events from './Events.vue'
 
 Vue.use(VueModal)
 
@@ -20,3 +21,4 @@ play('Vue Modal')
   .add('Scroll', Scroll)
   .add('ScrollSemanticUi', ScrollSemanticUi)
   .add('PreMount', PreMount)
+  .add('Events', Events)

--- a/src/components/Backdrop.js
+++ b/src/components/Backdrop.js
@@ -9,13 +9,11 @@ export default {
     backdropTransition: Object
   },
 
-  render (h: Function, { props, data, slots }: any) {
-    const listeners = data.on || {}
+  render (h: Function, { props, slots }: any) {
     const { show, backdropTransition } = props
 
     const transitionData = {
-      props: backdropTransition,
-      on: listeners
+      props: backdropTransition
     }
 
     return h('transition', transitionData, [

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -3,7 +3,6 @@
 import Backdrop from './Backdrop'
 import ModalContent from './ModalContent'
 import { addBodyClass, removeBodyClass, setBodyCss, getScrollBarWidth } from '../dom'
-import { only, wait } from '../utils'
 
 const openClassBody = 'modal-open'
 
@@ -29,8 +28,11 @@ export default {
         child.key = child.data.key = name
       })
 
-      this._prev = this._current
-      this._current = current
+      if (this._current !== current) {
+        this._prev = this._current
+        this._current = current
+      }
+
       this._modals[name] = {
         props,
         children,
@@ -80,18 +82,16 @@ export default {
   },
 
   render (h: Function) {
-    const numTransition = 2
-
     const modal = this._modals[this._current]
 
     const events = {
       // Only react the first transition event.
-      'before-enter': only(1, () => this.$emit('before-open', this._current)),
-      'before-leave': only(1, () => this.$emit('before-close', this._prev)),
+      'before-enter': () => this.$emit('before-open', this._current),
+      'before-leave': () => this.$emit('before-close', this._prev),
 
       // Need to wait until all transition element are completed
-      'after-enter': wait(numTransition, () => this.$emit('opened', this._current)),
-      'after-leave': wait(numTransition, () => this.$emit('closed', this._prev)),
+      'after-enter': () => this.$emit('opened', this._current),
+      'after-leave': () => this.$emit('closed', this._prev),
 
       'click-backdrop': () => this.$emit('click-backdrop')
     }

--- a/src/generators/Modal.js
+++ b/src/generators/Modal.js
@@ -34,6 +34,19 @@ export function generateModal (Vue: any, mediator: Mediator) {
     computed: {
       current () {
         return mediator.currentName
+      },
+
+      eventListners () {
+        const events = ['before-open', 'opened', 'before-close', 'closed']
+        const listeners = {}
+        events.forEach(event => {
+          listeners[event] = (name: string) => {
+            if (this.name === name) {
+              this.$emit(event, name)
+            }
+          }
+        })
+        return listeners
       }
     },
 
@@ -43,10 +56,18 @@ export function generateModal (Vue: any, mediator: Mediator) {
           .$mount()
           .$on('click-backdrop', () => mediator.pop())
       }
+
+      Object.keys(this.eventListners).forEach(event => {
+        portal.$on(event, this.eventListners[event])
+      })
     },
 
     beforeDestroy () {
       portal.unregister(this.name)
+
+      Object.keys(this.eventListners).forEach(event => {
+        portal.$off(event, this.eventListners[event])
+      })
     },
 
     render (h: Function) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,24 +11,6 @@ export function addStaticClass (
   }
 }
 
-function pruneCallbackByCount (predicate: (count: number) => boolean, cb: () => void) {
-  let count = 0
-  return () => {
-    count += 1
-    if (predicate(count)) {
-      cb()
-    }
-  }
-}
-
-export function only (times: number, cb: () => void): () => void {
-  return pruneCallbackByCount(count => count <= times, cb)
-}
-
-export function wait (times: number, cb: () => void): () => void {
-  return pruneCallbackByCount(count => count >= times, cb)
-}
-
 export function assert (value: any, message: string): void {
   if (!value) {
     throw new Error('[vue-modal] ' + message)


### PR DESCRIPTION
This supercedes #5. It introduce `before-open`  / `opened` / `before-close` / `closed` event on `<Modal>` component. 

Note that they are regarding modal content transition. The backdrop transition will not affect to the timing of triggering events. If the backdrop transition is too long than content one, the `opend` / `closed` event is triggered before ending backdrop transition.