### PR TITLE
fix: prevent to throw assertion error on ssr environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,8 @@ module.exports = {
   testRegex: '/test/.+\\.spec\\.js$',
   moduleNameMapper: {
     '^vue$': 'vue/dist/vue.common.js'
-  }
+  },
+  snapshotSerializers: [
+    'jest-serializer-vue'
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,10 +203,19 @@
       "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q==",
       "dev": true
     },
+    "@vue/server-test-utils": {
+      "version": "1.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/@vue/server-test-utils/-/server-test-utils-1.0.0-beta.25.tgz",
+      "integrity": "sha512-4XyKCIkUcIP001bl3/HBHml//ls3T005+iFKquM8MmUKFe5sjai7eL5RHnXR7zXZat0g0ElmgBtfdO3li2zMgg==",
+      "dev": true,
+      "requires": {
+        "cheerio": "^1.0.0-rc.2"
+      }
+    },
     "@vue/test-utils": {
-      "version": "1.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.20.tgz",
-      "integrity": "sha1-70UFNBuALz3hwGs8uGUTeMhzcfo=",
+      "version": "1.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.25.tgz",
+      "integrity": "sha512-mfvguEmEpAn0BuT4u+qm+0J1NTKgQS+ffUyWHY1QeSovIkJcy98fj1rO+PJgiZSEvGjjnDNX+qmofYFPLrofbA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.4"
@@ -2066,6 +2075,54 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "dev": true,
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -2366,6 +2423,28 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "condense-newlines": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "config-chain": {
@@ -5847,6 +5926,12 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
+    "is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6859,6 +6944,15 @@
       "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
       "dev": true
     },
+    "jest-serializer-vue": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jest-serializer-vue/-/jest-serializer-vue-2.0.2.tgz",
+      "integrity": "sha1-sjjvKGNX7GtIBCG9RxRQUJh9WbM=",
+      "dev": true,
+      "requires": {
+        "pretty": "2.0.0"
+      }
+    },
     "jest-snapshot": {
       "version": "23.4.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.0.tgz",
@@ -7344,6 +7438,12 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -7373,6 +7473,25 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -9136,6 +9255,28 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
+    },
+    "pretty": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
+      "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
+      "dev": true,
+      "requires": {
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -12385,9 +12526,9 @@
       }
     },
     "vue": {
-      "version": "2.5.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
-      "integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ==",
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
+      "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ==",
       "dev": true
     },
     "vue-hot-reload-api": {
@@ -12439,6 +12580,30 @@
       "integrity": "sha512-MC4jacHBhTPKtmcfzvaj2N7g6jgJ/Z/eIjZdt+yUaUOM1iKC0OUIlO/xCtz6OZFFTNUJs/1YNro2GN/lE+nOXA==",
       "dev": true
     },
+    "vue-server-renderer": {
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.5.17.tgz",
+      "integrity": "sha512-n62Fg4xv9ouxNloW2U3Bru2Jj+DkbnnrlzwuTkaU1o7CIDifG+r0+ILLMW0eVjgCjhKefHTYjwJ49RJ3bCjv1Q==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "hash-sum": "^1.0.2",
+        "he": "^1.1.0",
+        "lodash.template": "^4.4.0",
+        "lodash.uniq": "^4.5.0",
+        "resolve": "^1.2.0",
+        "serialize-javascript": "^1.3.0",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
     "vue-slim-modal": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/vue-slim-modal/-/vue-slim-modal-0.3.0.tgz",
@@ -12460,9 +12625,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.5.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz",
-      "integrity": "sha512-ZbuhCcF/hTYmldoUOVcu2fcbeSAZnfzwDskGduOrnjBiIWHgELAd+R8nAtX80aZkceWDKGQ6N9/0/EUpt+l22A==",
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
+      "integrity": "sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "release": "run-s lint flow test clean build"
   },
   "devDependencies": {
-    "@vue/test-utils": "^1.0.0-beta.20",
+    "@vue/server-test-utils": "^1.0.0-beta.25",
+    "@vue/test-utils": "^1.0.0-beta.25",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.5",
     "babel-plugin-external-helpers": "^6.22.0",
@@ -50,6 +51,7 @@
     "eslint-plugin-flowtype": "^2.49.3",
     "flow-bin": "^0.75.0",
     "jest": "^23.4.0",
+    "jest-serializer-vue": "^2.0.2",
     "npm-run-all": "^4.1.3",
     "rollup": "^0.62.0",
     "rollup-plugin-babel": "^3.0.7",
@@ -58,9 +60,10 @@
     "rollup-watch": "^4.3.1",
     "style-loader": "^0.21.0",
     "vbuild": "^7.2.4",
-    "vue": "^2.5.16",
+    "vue": "^2.5.17",
     "vue-play": "^3.2.1",
-    "vue-template-compiler": "^2.5.16"
+    "vue-server-renderer": "^2.5.17",
+    "vue-template-compiler": "^2.5.17"
   },
   "peerDependencies": {
     "vue": "^2.0.0"

--- a/src/generators/mediator.js
+++ b/src/generators/mediator.js
@@ -16,6 +16,10 @@ export function generateMediator (Vue: any): Mediator {
   }
 
   return new Vue({
+    // Mark this Vue instance is a mediator to Avoid infinite loop
+    // by trying to create another mediator in the beforeCreate hook in this mediator.
+    vueThinModalMediator: true,
+
     data: {
       stack: [],
       prevName: null

--- a/src/generators/mediator.js
+++ b/src/generators/mediator.js
@@ -16,7 +16,7 @@ export function generateMediator (Vue: any): Mediator {
   }
 
   return new Vue({
-    // Mark this Vue instance is a mediator to Avoid infinite loop
+    // Mark this Vue instance is a mediator to avoid infinite loop
     // by trying to create another mediator in the beforeCreate hook in this mediator.
     vueThinModalMediator: true,
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,21 +13,42 @@ interface VueThinModalOptions {
 let Vue: any
 
 function install (_Vue: any, options: VueThinModalOptions = {}) {
-  assert(!Vue, 'Already installed')
+  assert(Vue !== _Vue, 'Already installed')
 
   Vue = _Vue
 
-  Vue.prototype.$modal = generateMediator(Vue)
+  Object.defineProperty(Vue.prototype, '$modal', {
+    get() {
+      return this.$root.$_vueThinModal
+    }
+  })
+
   Vue.component('modal', Modal)
   Vue.component('modal-portal', ModalPortal)
 
   if (options.autoMountPortal !== false) {
+    // If the portal is auto mounted, should share singleton mediator
+    // because the root instance of the portal component is different with the app one.
+    // Note that auto mount will not be used on SSR environment.
+    Vue.prototype.$_vueThinModal = generateMediator(Vue)
+
+    // Mount portal component under the body element.
     const ModalPortalCtor = Vue.extend(ModalPortal)
     const portal = new ModalPortalCtor()
 
     onReady(() => {
       portal.$mount()
       appendToBody(portal.$el)
+    })
+  } else {
+    // If the portal will be manually mounted, generate the medator for each root instance.
+    // Then we can handle SSR environment which may create multiple instances of portal among each sessions.
+    Vue.mixin({
+      beforeCreate() {
+        if (!this.$parent) {
+          this.$_vueThinModal = generateMediator(Vue)
+        }
+      }
     })
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ function install (_Vue: any, options: VueThinModalOptions = {}) {
     // Then we can handle SSR environment which may create multiple instances of portal among each sessions.
     Vue.mixin({
       beforeCreate() {
-        if (!this.$parent) {
+        if (!this.$parent && !this.$options.vueThinModalMediator) {
           this.$_vueThinModal = generateMediator(Vue)
         }
       }

--- a/test/__snapshots__/modal.spec.js.snap
+++ b/test/__snapshots__/modal.spec.js.snap
@@ -1,3 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Modal allows to manually mount modal portal when autoMountPortal: false 1`] = `"<div><!----> <div class=\\"modal-wrapper\\"><div class=\\"modal-backdrop modal-backdrop-enter modal-backdrop-enter-active\\"></div><div role=\\"dialog\\" aria-hidden=\\"false\\" class=\\"modal-content-wrapper\\"><p class=\\"modal-content modal-content-enter modal-content-enter-active\\">Hello!</p></div></div></div>"`;
+exports[`Modal allows to manually mount modal portal when autoMountPortal: false 1`] = `
+<div>
+  <!---->
+  <div class="modal-wrapper">
+    <div class="modal-backdrop"></div>
+    <div role="dialog" aria-hidden="false" class="modal-content-wrapper">
+      <p class="modal-content">Hello!</p>
+    </div>
+  </div>
+</div>
+`;

--- a/test/modal.spec.js
+++ b/test/modal.spec.js
@@ -1,4 +1,5 @@
 import { mount, createLocalVue } from '@vue/test-utils'
+import { render } from '@vue/server-test-utils'
 import VueThinModal from '../src'
 
 describe('Modal', () => {
@@ -27,5 +28,31 @@ describe('Modal', () => {
     wrapper.vm.$modal.push('test')
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  describe('SSR', () => {
+    const localVue = createLocalVue()
+    localVue.use(VueThinModal, {
+      autoMountPortal: false
+    })
+
+    it('not throws when render modal-portal in multiple times', () => {
+      const App = {
+        template: `<div>
+          <modal name="test">
+            <p>Hi</p>
+          </modal>
+          <modal-portal />
+        </div>`
+      }
+
+      expect(() => {
+        render(App, { localVue })
+      }).not.toThrow()
+
+      expect(() => {
+        render(App, { localVue })
+      }).not.toThrow()
+    })
   })
 })


### PR DESCRIPTION
fix #12

On SSR environment, the mediator instance will be re-used among different sessions and be set multiple portal instances. Then it throws assertion error for multiple modal-portal instance.

I've modified that the mediator instance will be created for each root Vue instance when `autoMountPortal: false` so that it will not be re-used and ensure only modal-portal instance for each session.

Note that the mediator will be a singleton when `autoMountPortal: true` because it will be shared different root instances in that case.