### PR TITLE
Accept string as `content-transition` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ new Vue({
 
   If `true`, the modal will not be closed by clicking backdrop.
 
-* `content-transition` - Object
+* `content-transition` - String | Object
 
-  It is the same options as the props of Vue's `<transition>` component. You can customize the modal content transition by using this prop. If omitted a default transition will be used.
+  The transition property for the modal content. When passing `String` as the value, it will be used as transition name. When passing `Object`, it may contain the same options for the Vue's `<transition>` component. If omitted, the default value – `{ name: 'modal-content' }` – will be used.
 
-* `backdrop-transition` - Object
+* `backdrop-transition` - String | Object
 
-  Same as `content-transition` except for the modal backdrop.
+  Same as `content-transition` except for the modal backdrop. The default value is `{ name: 'modal-backdrop' }`
 
 #### Events
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -11,13 +11,13 @@ export default {
     disableBackdrop: Boolean,
     preMount: Boolean,
     backdropTransition: {
-      type: Object,
+      type: [String, Object],
       default() {
         return { name: 'modal-backdrop' }
       }
     },
     contentTransition: {
-      type: Object,
+      type: [String, Object],
       default() {
         return { name: 'modal-content' }
       }
@@ -27,6 +27,22 @@ export default {
   computed: {
     current() {
       return this.$modal.currentName
+    },
+
+    computedBackdropTransition() {
+      if (typeof this.contentTransition === 'string') {
+        return { name: this.backdropTransition }
+      }
+
+      return this.backdropTransition
+    },
+
+    computedContentTransition() {
+      if (typeof this.contentTransition === 'string') {
+        return { name: this.contentTransition }
+      }
+
+      return this.contentTransition
     },
 
     eventListners() {
@@ -74,8 +90,8 @@ export default {
       {
         show: true,
         backdropTransition: this.backdropTransition,
-        contentTransition: this.contentTransition,
-        disableBackdrop: this.disableBackdrop
+        contentTransition: this.computedContentTransition,
+        disableBackdrop: this.computedDisableBackdrop
       },
       this.$slots
     ]


### PR DESCRIPTION
Issue: #18 

This PR enables modal component to accept string as a value for `content-transition` and `backdrop-transition`.

@ktsn I've tested this locally and confirmed it's working, but I have no idea how to write test on this 🤔  Any idea? (not needed?)