### PR TITLE
feat: add overlay option

### DIFF
--- a/src/generators/mediator.js
+++ b/src/generators/mediator.js
@@ -34,7 +34,7 @@ export function generateMediator(Vue: any): Mediator {
     },
 
     methods: {
-      push(name: string): void {
+      push(name: string, overlay?: boolean = false): void {
         const focusedElement = activeElement()
         if (focusedElement) {
           focusedElement.blur()
@@ -42,7 +42,8 @@ export function generateMediator(Vue: any): Mediator {
 
         const item = {
           name,
-          focusedElement
+          focusedElement,
+          overlay
         }
 
         // Prevent to make reactive
@@ -58,9 +59,9 @@ export function generateMediator(Vue: any): Mediator {
         }
       },
 
-      replace(name: string): void {
+      replace(name: string, overlay?: boolean = false): void {
         this.pop()
-        this.push(name)
+        this.push(name, overlay)
       },
 
       _setPortal(portal: any): void {


### PR DESCRIPTION
To allow for 'modal on modal' display, I added `overlay` option into `$modal.push/replace` methods.

- $modal.push(name, [overlay = false])
- $modal.replace(name, [overlay = false])

## Usage:

- Modal1
- Modal2
- Modal3

```
$modal.push('Modal1') // show Modal1
$modal.push('Modal2', true) // show Modal2 on Modal1
$modal.push('Modal3') // show Modal3 only
$modal.pop() // show Modal2 on Modal1
$modal.pop() // show Modal1
```