### PR TITLE
Emit click-backdrop event when clicking backdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ new Vue({
 
   Emitted after closing a modal.
 
+* `click-backdrop`
+
+  Emitted when clicking backdrop.
+
 #### Slots
 
 * `(default)` - A modal content. Must be only element.

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -46,7 +46,13 @@ export default {
     },
 
     eventListners() {
-      const events = ['before-open', 'opened', 'before-close', 'closed']
+      const events = [
+        'before-open',
+        'opened',
+        'before-close',
+        'closed',
+        'click-backdrop',
+      ]
       const listeners = {}
       events.forEach((event) => {
         listeners[event] = (name: string) => {

--- a/src/components/ModalContent.js
+++ b/src/components/ModalContent.js
@@ -38,7 +38,6 @@ export default {
         },
         on: {
           click: (event: Event) => {
-            if (disableBackdrop) return
             if (event.target !== event.currentTarget) return
 
             if (listeners['click-backdrop']) {

--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -68,7 +68,10 @@ export default {
 
   beforeMount() {
     this.$on('click-backdrop', () => {
-      this.$modal.pop()
+      const modal = this.modals[this.current]
+      if (!modal.props.disableBackdrop) {
+        this.$modal.pop()
+      }
     })
 
     this.$on('before-open', () => {
@@ -101,7 +104,7 @@ export default {
       'after-enter': () => this.$emit('opened', this.current),
       'after-leave': () => this.$emit('closed', this.prev),
 
-      'click-backdrop': () => this.$emit('click-backdrop'),
+      'click-backdrop': () => this.$emit('click-backdrop', this.current),
     }
 
     if (modal) {


### PR DESCRIPTION
This PR enables the parent component of a modal to know when the modal's backdrop is clicked.

I want to know when a user clicks the backdrop because I want to show an alert or something like that before closing a modal if the modal has a form and its text box is filled in.

Though I found the click-backdrop event emitted when clicking a backdrop, it does not reach the parent component of a modal. So I modified the code around the click-backdrop event so that the event is to send to the parent component.

What do you think?